### PR TITLE
Single digit bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Spyder files
+.spyderproject
+
+# Byte-compiled / optimized / DLL files
+*.py[cod]

--- a/humidity2digit.py
+++ b/humidity2digit.py
@@ -118,6 +118,11 @@ while True:
 		r = [255,0,0] # red if lower
 	hum_prev = hum_int
 	hum =  str(hum_int) # convert reading to string
+	
+	# add a leading zero for single digit readings
+	if hum_int < 10:
+		hum = '0' + hum
+	
 	image = numToMatrix(hum[1]) + space + numToMatrix(hum[0]) # build image from two digits plus spacer
 	ap.set_pixels(image)
 	time.sleep(0.5)


### PR DESCRIPTION
A humidity reading less than 10 generates an index out of range error because the string only has a single character.  I fixed this bug by adding a check for single digit readings and adding a leading zero when needed.

Daddy the Runner
